### PR TITLE
Add Support for Airspy HF+ Discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@ ARG TARGETPLATFORM
 ENV TARGETPLATFORM "$TARGETPLATFORM"
 
 RUN apt-get update
-RUN apt-get install -y rtl-sdr librtlsdr-dev wget
+RUN apt-get install -y --no-install-recommends rtl-sdr librtlsdr-dev wget unzip build-essential cmake libusb-1.0-0-dev pkg-config
 
 RUN set -ex; \
   if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-    wget https://airspy.com/downloads/spyserver-linux-x64.tgz;\
+    wget https://airspy.com/downloads/spyserver-linux-x64.tgz --no-check-certificate;\
     tar xvzf spyserver-linux-x64.tgz;\
     rm spyserver-linux-x64.tgz;\
   elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
-    wget https://airspy.com/downloads/spyserver-arm32.tgz;\
+    wget https://airspy.com/downloads/spyserver-arm32.tgz --no-check-certificate;\
     tar xvzf spyserver-arm32.tgz;\
     rm spyserver-arm32.tgz;\
   fi;
@@ -20,6 +20,19 @@ RUN set -ex; \
 RUN mv spyserver spyserver_ping /usr/bin && \
     mkdir -p /etc/spyserver && \
     mv spyserver.config /etc/spyserver
+
+RUN wget https://github.com/airspy/airspyhf/archive/master.zip --no-check-certificate &&\
+    unzip master.zip &&\
+    cd airspyhf-master &&\
+    mkdir build &&\
+    cd build &&\
+    cmake ../ -DINSTALL_UDEV_RULES=ON &&\
+    make &&\
+    make install &&\
+    ldconfig &&\
+    cd / &&\
+    rm master.zip &&\
+    rm -R airspyhf-master
 
 COPY entrypoint.sh .
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
These changes to the dockerfile install the dependencies required to make use of the Airspy HF devices.

This makes the spyserver image work plug and play with the Airspy HF+ Discovery (Tested).
Unfortunately, this does increase the image size by quite a bit, from 103 to 371 MB.

I'm far from a docker expert, but this worked for me and I figure that this might help others with the same device. If you have a way to simplify this, please do!